### PR TITLE
fix: declare platforms in manifest.json for HA 2025.x+

### DIFF
--- a/custom_components/openhab/manifest.json
+++ b/custom_components/openhab/manifest.json
@@ -9,6 +9,16 @@
     "bs4",
     "python-openhab>=2.17.1"
   ],
+  "platforms": [
+    "binary_sensor",
+    "cover",
+    "device_tracker",
+    "light",
+    "media_player",
+    "sensor",
+    "switch",
+    "climate"
+  ],
   "version": "0.2",
   "config_flow": true,
   "codeowners": [


### PR DESCRIPTION
## Problem

After re-adding the integration, HA throws:

```
ModuleNotFoundError: Platform openhab.binary_sensor not found
```

This happens even though `binary_sensor.py` physically exists in the integration directory.

## Root Cause

Starting with HA 2025.x, the loader (`homeassistant/loader.py`) requires all platforms to be **explicitly declared** in `manifest.json` under a `"platforms"` key. The method `_get_platform_cached_or_raise()` raises `ModuleNotFoundError` if a platform is not in this list, regardless of whether the `.py` file is present.

Without `"platforms"` declared, all platforms fail to load and the entire integration setup errors out on the first platform (`binary_sensor`).

## Fix

Added the `"platforms"` array to `manifest.json` listing all 8 platforms used by this integration:

```json
"platforms": [
  "binary_sensor",
  "cover",
  "device_tracker",
  "light",
  "media_player",
  "sensor",
  "switch",
  "climate"
]
```

This mirrors what is defined in `PLATFORMS` in `const.py`.

Note: `camera` is intentionally excluded since `camera.py` contains only a stub (`pass`) and is not in `PLATFORMS`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Declared support for additional integration platforms including binary sensors, covers, device trackers, lights, media players, sensors, switches, and climate controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->