### PR TITLE
fix: wrap all coordinator exceptions as UpdateFailed to avoid setup_error on startup race

### DIFF
--- a/custom_components/openhab/coordinator.py
+++ b/custom_components/openhab/coordinator.py
@@ -395,6 +395,14 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
         Polling is active until _listen_sse_events() disables it after a
         confirmed SSE connection. After that this method may still be invoked
         explicitly via async_request_refresh() as a fallback (e.g. on reconnect).
+
+        All exceptions - including connection errors and timeouts - are caught
+        and re-raised as UpdateFailed so that async_config_entry_first_refresh()
+        converts them into ConfigEntryNotReady.  This causes HA to automatically
+        retry setup instead of marking the integration as permanently broken
+        (setup_error), which is the correct behaviour when openHAB is simply not
+        yet reachable at HA startup time (e.g. after a fast HACS-triggered restart
+        where openHAB needs a few extra seconds to come up).
         """
         try:
             if self.version is None or len(self.version) == 0:
@@ -433,3 +441,9 @@ class OpenHABDataUpdateCoordinator(DataUpdateCoordinator):
 
         except ApiClientException as exception:
             raise UpdateFailed(exception) from exception
+        except UpdateFailed:
+            raise
+        except Exception as exception:  # noqa: BLE001
+            raise UpdateFailed(
+                f"Unexpected error communicating with openHAB: {exception}"
+            ) from exception


### PR DESCRIPTION
## Problem

After a fast restart (e.g. triggered by HACS updates), the integration ends up in `setup_error` state with all entities showing `unavailable`.

## Root Cause

`_async_update_data()` only caught `ApiClientException`. Any other exception from `async_get_version()` — such as a connection error or timeout when the openHAB server hasn't finished starting up yet — escaped uncaught.

`async_config_entry_first_refresh()` distinguishes two cases:
- `UpdateFailed` → converts to `ConfigEntryNotReady` → HA **retries** setup automatically
- Any other exception → **`setup_error`** (permanent failure, no automatic retry)

So a plain connection timeout at the wrong moment permanently breaks the integration and requires a manual reload.

## Reproducer

1. HA and openHAB running normally
2. HACS update triggers a fast HA restart
3. HA comes up before openHAB finishes restarting
4. `async_get_version()` raises a connection error
5. Exception escapes `_async_update_data()` uncaught → `setup_error`

The first boot after a manual restart was fine because the restart was slower, giving openHAB enough time to be ready.

## Fix

Added a catch-all `except Exception` at the bottom of `_async_update_data()` that wraps any unexpected exception as `UpdateFailed`. This ensures HA always retries setup instead of giving up permanently.

```python
except Exception as exception:  # noqa: BLE001
    raise UpdateFailed(
        f"Unexpected error communicating with openHAB: {exception}"
    ) from exception
```

`UpdateFailed` and `ApiClientException` are still handled separately before the catch-all so existing behaviour is unchanged for those paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for OpenHAB connectivity issues to ensure automatic retry behavior works consistently during startup and reconnection attempts, improving recovery from temporary connection disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->